### PR TITLE
Add LHBG to the list of existing resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ With that in mind, it should be:
 | Beginner friendy   | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Up-to-date         | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | Looks nice         | :x:                | :white_check_mark: | :x:                | :shrug:            | :white_check_mark: | :white_check_mark: |
-| Supports comments  | :x:                | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                |
+| Supports comments  | :x:                | :x:                | :x:                | :x:                | :white_check_mark: | :x:                |
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ With that in mind, it should be:
 
 ## What's wrong with existing resources?
 
-|                     | Wiki | LYAH | Real world Haskell | These Docs | Various Books
-| ----- | ----- | ----------------- | -------- | -------- | -- |
-| Free   |     :white_check_mark:    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:
-| Community editable | :white_check_mark:  | :x: | :x: | :white_check_mark: | :x:
-| Beginner friendy   | :x:   | :white_check_mark: | :white_check_mark: |  :white_check_mark: | :white_check_mark:
-| Up-to-date   | :x:  | :x: | :x: | :white_check_mark: | :white_check_mark:
-| Looks nice   | :x:    | :white_check_mark: | :x: | :white_check_mark: | :white_check_mark:
-| Supports comments   | :x:        | :x: | :x: | :white_check_mark: | :x:
+|                    | Wiki               | LYAH               | RWH                | LHBG               | These Docs         | Various Books      |
+| ------------------ | ------------------ | -----------------  | ------------------ | ------------------ | ------------------ | ------------------ |
+| Free               | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x:                |
+| Community editable | :white_check_mark: | :x:                | :x:                | :pushpin:          | :white_check_mark: | :x:                |
+| Beginner friendy   | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Up-to-date         | :x:                | :x:                | :x:                | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Looks nice         | :x:                | :white_check_mark: | :x:                | :shrug:            | :white_check_mark: | :white_check_mark: |
+| Supports comments  | :x:                | :x:                | :white_check_mark: | :x:                | :white_check_mark: | :x:                |
+
 
 
 There are many great resources, but:


### PR DESCRIPTION
Hello! [www.lhbg-book.link](http://www.lhbg-book.link/) is another free haskell book. Since it cannot be grouped with "Various Books" on the table, I'm suggesting to add it to the table. I've added a pushpin icon for community editable, because users can submit issues and pull-request (but I reserve the right to make changes as I like), and shrug on "looks nice" because 🤷 .

I've also formatted it a little bit to make contribution easier, and abbreviated RWH.

Also, I think RWH does have support for comments? I haven't tested if it still works though.