### PR TITLE
Remove inaccurate comment that Haskell compiles to C

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,7 +3,7 @@
 !!! warning
     This documentation is under construction! If you're a newcomer to Haskell, come back here soon, but for now, try out other resources. If you're interesting in contributing, please get in touch or submit a PR!
 
-Haskell is a general purpose programming language. It is unique in being both very principled in its design (pure functions only, simple syntax, very expressive types), but also practical (heavily-engineered compiler into C that can generate fast code).
+Haskell is a general purpose programming language. It is unique in being both very principled in its design (pure functions only, simple syntax, very expressive types), but also practical (heavily-engineered compiler that can generate fast code).
 
 - Pros: highly modular code, low boilerplate, easy and safe refactoring
 - Cons: no manual memory management, some [gaps in ecosystem](https://github.com/Gabriella439/post-rfc/blob/main/sotu.md)


### PR DESCRIPTION
In reality, although C is a possible compile target, it's almost never competitive in performance.  Instead, Haskell is typically compiled either directly to native code using native code generation, or via LLVM.  This is too much detail for an into page, so I just deleted the misleading words.