### PR TITLE
Suggestion: remove LambdaCase in first example

### DIFF
--- a/docs/docs/gettingstarted/example.md
+++ b/docs/docs/gettingstarted/example.md
@@ -15,9 +15,8 @@ data Piece where -- (3)!
     Rook   :: Piece
 
 isBishop :: Piece -> Bool
-isBishop = \case
-    Bishop -> True
-    _ -> False
+isBishop Bishop = True
+isBishop _ = False
 ```
 
 1. Language extensions go here.


### PR DESCRIPTION
Using LambdaCase in this first example (even if it's nor explained) seems to be starting out on the wrong foot.  It's a non-standard language feature that's missing from language extensions, and also fails to convey the declarative style of code as well as pattern matching and multiple equations does.